### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,29 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+    # ----- SETUP
     - name: Setup MSBuild path
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.2
+    # ----- BUILD
     # Do not use `dotnet restore`, it ignores packages.config
     - name: Restore NuGet packages
       run: nuget restore -SolutionDir ..
     - name: Build
       run: msbuild -t:Build -p:Configuration=Release
+    # ----- NUGET RELEASE
+    - name: Build Nupgks
+      run: nuget pack Meplato.Store2.csproj -Properties Configuration=Release
+    - name: Push to Nuget.org
+      run: nuget push -ApiKey ${{ secrets.NUGET_KEY }} -Source https://api.nuget.org/v3/index.json Meplato.Store2*.nupkg
+    # ----- GITHUB RELEASE
     - name: Install hub
       uses: geertvdc/setup-hub@master
     - name: run hub commands
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${env:GITHUB_REF}" ${env:GITHUB_REF}
+      run: |
+        $tag = ${env:GITHUB_REF}.Substring(11)
+        hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${tag}" ${tag}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{GITHUB_REF}}" ${{GITHUB_REF}}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{ env.GITHUB_REF }}" ${{ env.GITHUB_REF }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,8 @@ jobs:
       run: msbuild -t:Build -p:Configuration=Release
     - name: Install hub
       uses: geertvdc/setup-hub@master
-    - name: Get tag and version
-      run: |
-        echo ::set-env name=RELEASE_HASH::${GITHUB_SHA:10}
     - name: run hub commands
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{ env.RELEASE_HASH }}" ${{ env.RELEASE_HASH }}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${GITHUB_SHA}" ${GITHUB_SHA}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,12 @@ jobs:
       run: msbuild -t:Build -p:Configuration=Release
     - name: Install hub
       uses: geertvdc/setup-hub@master
+    - name: Get tag and version
+      run: |
+        echo ::set-env name=RELEASE_TAG::${GITHUB_REF:10}
+        echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
     - name: run hub commands
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{ env.GITHUB_REF }}" ${{ env.GITHUB_REF }}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{ env.RELEASE_TAG }}" ${{ env.RELEASE_TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v**"
 jobs:
   build:
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,9 @@ jobs:
       uses: geertvdc/setup-hub@master
     - name: Get tag and version
       run: |
-        echo ::set-env name=RELEASE_TAG::${GITHUB_REF:10}
-        echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
+        echo ::set-env name=RELEASE_HASH::${GITHUB_SHA:10}
     - name: run hub commands
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{ env.RELEASE_TAG }}" ${{ env.RELEASE_TAG }}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{ env.RELEASE_HASH }}" ${{ env.RELEASE_HASH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-    paths:
-      - .github/workflows/release.yml
+    tags:
+      - 'v*'
 jobs:
   build:
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: Test
+name: Release
 on:
   push:
     paths:
-      - .github/workflows/test.yml
+      - .github/workflows/release.yml
 jobs:
   build:
     defaults:
@@ -19,4 +19,11 @@ jobs:
     - name: Restore NuGet packages
       run: nuget restore -SolutionDir ..
     - name: Build
-      run: msbuild -t:Build -p:Configuration=Debug
+      run: msbuild -t:Build -p:Configuration=Release
+    - name: Install hub
+      uses: geertvdc/setup-hub@master
+    - name: run hub commands
+      env:
+        GITHUB_USER: ${{ secrets.GITHUB_USER }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${GITHUB_REF}" ${GITHUB_REF}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${GITHUB_SHA}" ${GITHUB_SHA}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${env:GITHUB_REF}" ${env:GITHUB_REF}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
       run: msbuild -t:Build -p:Configuration=Release
     # ----- NUGET RELEASE
     - name: Build Nupgks
-      run: nuget pack Meplato.Store2.csproj -Properties Configuration=Release
+      run: |
+        $tag = ${env:GITHUB_REF}.Substring(11)
+        nuget pack Meplato.Store2.csproj -Properties Configuration=Release -Version ${tag}
     - name: Push to Nuget.org
       run: nuget push -ApiKey ${{ secrets.NUGET_KEY }} -Source https://api.nuget.org/v3/index.json Meplato.Store2*.nupkg
     # ----- GITHUB RELEASE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${GITHUB_REF}" ${GITHUB_REF}
+      run: hub release create --attach bin\Release\Meplato.Store2.dll -m "Release ${{GITHUB_REF}}" ${{GITHUB_REF}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup MSBuild path
       uses: microsoft/setup-msbuild@v1.0.0
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1.0.2
+    # Do not use `dotnet restore`, it ignores packages.config
+    - name: Restore NuGet packages
+      run: nuget restore -SolutionDir .
     - name: Build
       run: msbuild -t:Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Restore NuGet packages
       run: nuget restore -SolutionDir ..
     - name: Build
-      run: msbuild -t:Build
+      run: msbuild -t:Build -p:Configuration=Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
       uses: NuGet/setup-nuget@v1.0.2
     # Do not use `dotnet restore`, it ignores packages.config
     - name: Restore NuGet packages
-      run: nuget restore -SolutionDir .
+      run: nuget restore -SolutionDir ..
     - name: Build
       run: msbuild -t:Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+on:
+  push:
+    paths:
+      - .github/workflows/test.yml
+jobs:
+  build:
+    defaults:
+      run:
+        working-directory: src/Meplato.Store2
+    name: Build and deploy
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup MSBuild path
+      uses: microsoft/setup-msbuild@v1.0.0
+    - name: Build
+      run: msbuild -t:Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: csharp
-solution: src/Meplato.Store2.sln


### PR DESCRIPTION
This removed Travis-CI and replaces it with 2 GitHub Actions/Workflows.
We now have a workflow for running a simple builld in debug mode and
another for releasing a proper build to nuget.org and to the github releases page.

Closes: #6 