### PR TITLE
Update NuGet deployment

### DIFF
--- a/src/Meplato.Store2/LICENSE.md
+++ b/src/Meplato.Store2/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright (c) 2015 Meplato GmbH <http://www.meplato.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/Meplato.Store2/Meplato.Store2.csproj
+++ b/src/Meplato.Store2/Meplato.Store2.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="LICENSE.md" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Meplato.Store2/Meplato.Store2.nuspec
+++ b/src/Meplato.Store2/Meplato.Store2.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>Meplato Store API</title>
+    <authors>Meplato GmbH</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="file">LICENSE.md</license>
+    <projectUrl>https://developer.meplato.com/store2</projectUrl>
+    <description>Meplato Store API for .NET allows you to manage and modify electronic product catalogs in the Meplato Catalog Cloud.</description>
+    <releaseNotes>Updated all dependencies.</releaseNotes>
+    <copyright>$copyright$</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.md" target="" />
+  </files>
+</package>

--- a/src/Meplato.Store2/Properties/AssemblyInfo.cs
+++ b/src/Meplato.Store2/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("Meplato Store 2")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("Meplato Store API")]
+[assembly: AssemblyDescription("Meplato Store API for .NET allows you to manage and modify electronic product catalogs in the Meplato Catalog Cloud.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Meplato Store 2")]
+[assembly: AssemblyCompany("Meplato GmbH")]
+[assembly: AssemblyProduct("Meplato Store")]
 [assembly: AssemblyCopyright("Copyright © 2015 Meplato GmbH")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
When deploying new versions to NuGet, certain fields were missing to
make it look acceptable on NuGet gallery. E.g. if you search for Meplato
on https://nuget.org, you won't see the author, no description, no
license file, and no link to the Developer site.

I hope to fix this by generating a NuGet spec from `nuget spec *.csproj`
before completing `AssemblyInfo.cs`. This should hopefully get us a more
complete description on NuGet.