### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:1": {
-      "version" : "4.7.2"
+      "version" : "7"
     }
   }
 }


### PR DESCRIPTION
TIL: .NET framework is not the same as .NET core (or just .NET).

Just use .NET 7 for the devcontainers, and see if we can migrate the project at some point.